### PR TITLE
v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Entries are listed in reverse chronological order.
 
-## Unreleased
+## 0.3.0
 
 * Migrate to `group` 0.12, `jubjub` 0.9, `pasta_curves` 0.4
 * Added support for `no-std` builds, via new (default-enabled) `std` and `alloc`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,9 @@
 name = "reddsa"
 edition = "2021"
 # When releasing to crates.io:
-# - Update html_root_url
 # - Update CHANGELOG.md
 # - Create git tag.
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Henry de Valence <hdevalence@hdevalence.ca>",
     "Deirdre Connolly <durumcrustulum@gmail.com>",
@@ -15,7 +14,7 @@ authors = [
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ZcashFoundation/reddsa"
-categories = ["cryptography"]
+categories = ["cryptography", "no_std"]
 keywords = ["cryptography", "crypto", "zcash"]
 description = "A standalone implementation of the RedDSA signature scheme."
 


### PR DESCRIPTION
Update changelog and TOML for 0.3.0 release.

I was not sure about the `html_root_url` reference but it seems it's not used anymore so I deleted the comment.