### PR TITLE
Fix alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ blake2b_simd = { version = "1", default-features = false }
 byteorder = { version = "1.4", default-features = false }
 group = { version = "0.12", default-features = false }
 jubjub = { version = "0.9", default-features = false }
-pasta_curves = { version = "0.4", default-features = false, features = ["alloc"] }
+pasta_curves = { version = "0.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = { version = "1.0", optional = true }
@@ -45,6 +45,9 @@ proptest = "1.0"
 rand = "0.8"
 rand_chacha = "0.3"
 serde_json = "1.0"
+
+[dev-dependencies.pasta_curves]
+features = ["alloc"]
 
 [features]
 std = ["blake2b_simd/std", "thiserror", "zeroize", "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rand = "0.8"
 rand_chacha = "0.3"
 serde_json = "1.0"
 
+# `alloc` is only used in test code
 [dev-dependencies.pasta_curves]
 features = ["alloc"]
 


### PR DESCRIPTION
### Problem
`pasta_curves/alloc`, which requires `#[global_allocator]`, is not disabled on default-features=false
### Solution
- `pasta_curves/alloc` disabled by default
- `pasta_curves/alloc` enabled in dev-dependencies