### PR TITLE
port improvements from Zebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ features = ["nightly"]
 blake2b_simd = { version = "1", default-features = false }
 byteorder = { version = "1.4", default-features = false }
 group = { version = "0.12", default-features = false }
+hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 jubjub = { version = "0.9", default-features = false }
 pasta_curves = { version = "0.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
@@ -53,7 +54,7 @@ features = ["alloc"]
 [features]
 std = ["blake2b_simd/std", "thiserror", "zeroize", "alloc",
        "serde"] # conditional compilation for serde not complete (issue #9)
-alloc = []
+alloc = ["hex"]
 nightly = []
 default = ["std"]
 

--- a/src/orchard.rs
+++ b/src/orchard.rs
@@ -15,13 +15,17 @@ use crate::{private, SigType};
 #[cfg(feature = "alloc")]
 use crate::scalar_mul::{LookupTable5, NonAdjacentForm, VartimeMultiscalarMul};
 
-/// The byte-encoding of the basepoint for `OrchardSpendAuthSig`.
+/// The byte-encoding of the basepoint for `SpendAuthSig` on the [Pallas curve][pallasandvesta].
+///
+/// [pallasandvesta]: https://zips.z.cash/protocol/nu5.pdf#pallasandvesta
+// Reproducible by pallas::Point::hash_to_curve("z.cash:Orchard")(b"G").to_bytes()
 const ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES: [u8; 32] = [
     99, 201, 117, 184, 132, 114, 26, 141, 12, 161, 112, 123, 227, 12, 127, 12, 95, 68, 95, 62, 124,
     24, 141, 59, 6, 214, 241, 40, 179, 35, 85, 183,
 ];
 
-/// The byte-encoding of the basepoint for `OrchardBindingSig`.
+/// The byte-encoding of the basepoint for `BindingSig` on the Pallas curve.
+// Reproducible by pallas::Point::hash_to_curve("z.cash:Orchard-cv")(b"r").to_bytes()
 const ORCHARD_BINDINGSIG_BASEPOINT_BYTES: [u8; 32] = [
     145, 90, 60, 136, 104, 198, 195, 14, 47, 128, 144, 238, 69, 215, 110, 64, 72, 32, 141, 234, 91,
     35, 102, 79, 187, 9, 164, 15, 85, 68, 244, 7,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -8,17 +8,34 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
 //! RedDSA Signatures
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
 use crate::SigType;
 
 /// A RedDSA signature.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signature<T: SigType> {
     pub(crate) r_bytes: [u8; 32],
     pub(crate) s_bytes: [u8; 32],
     pub(crate) _marker: PhantomData<T>,
+}
+
+impl<T: SigType> fmt::Debug for Signature<T> {
+    #[cfg(feature = "alloc")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Signature")
+            .field("r_bytes", &hex::encode(&self.r_bytes))
+            .field("s_bytes", &hex::encode(&self.s_bytes))
+            .finish()
+    }
+    #[cfg(not(feature = "alloc"))]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Signature")
+            .field("r_bytes", &self.r_bytes)
+            .field("s_bytes", &self.s_bytes)
+            .finish()
+    }
 }
 
 impl<T: SigType> From<[u8; 64]> for Signature<T> {

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -10,6 +10,7 @@
 
 use core::{
     convert::{TryFrom, TryInto},
+    fmt,
     hash::Hash,
     marker::PhantomData,
 };
@@ -24,11 +25,26 @@ use crate::{Error, Randomizer, SigType, Signature, SpendAuth};
 /// This is useful for representing a compressed verification key; the
 /// [`VerificationKey`] type in this library holds other decompressed state
 /// used in signature verification.
-#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerificationKeyBytes<T: SigType> {
     pub(crate) bytes: [u8; 32],
     pub(crate) _marker: PhantomData<T>,
+}
+
+impl<T: SigType> fmt::Debug for VerificationKeyBytes<T> {
+    #[cfg(feature = "alloc")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerificationKeyBytes")
+            .field("bytes", &hex::encode(&self.bytes))
+            .finish()
+    }
+    #[cfg(not(feature = "alloc"))]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerificationKeyBytes")
+            .field("bytes", &self.bytes)
+            .finish()
+    }
 }
 
 impl<T: SigType> From<[u8; 32]> for VerificationKeyBytes<T> {


### PR DESCRIPTION
While deduplicating RedPallas code in Zebra to use this crate instead, I noticed some changes were added there after this crate was created.

This ports those. It's mostly documentation, and a Display implementation that uses hex encoding (there is uses a `HexDebug` helper which I didn't want to copy here, so I implemented it manually)