### PR TITLE
change: Refactor & optimize the NAF

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ rand = "0.8"
 rand_chacha = "0.3"
 serde_json = "1.0"
 frost-rerandomized = { version = "0.2", features=["test-impl"] }
+num-bigint = "0.4.3"
+num-traits = "0.2.15"
 
 # `alloc` is only used in test code
 [dev-dependencies.pasta_curves]

--- a/src/orchard/tests.rs
+++ b/src/orchard/tests.rs
@@ -1,6 +1,8 @@
-use crate::scalar_mul::VartimeMultiscalarMul;
+use crate::scalar_mul::{self, VartimeMultiscalarMul};
 use alloc::vec::Vec;
+use group::ff::Field;
 use group::{ff::PrimeField, GroupEncoding};
+use rand::thread_rng;
 
 use pasta_curves::arithmetic::CurveExt;
 use pasta_curves::pallas;
@@ -27,8 +29,7 @@ fn orchard_binding_basepoint() {
 // #[test]
 #[allow(dead_code)]
 fn gen_pallas_test_vectors() {
-    use group::{ff::Field, Group};
-    use rand::thread_rng;
+    use group::Group;
     use std::println;
 
     let rng = thread_rng();
@@ -104,4 +105,13 @@ fn test_pallas_vartime_multiscalar_mul() {
 
     let product = pallas::Point::vartime_multiscalar_mul(scalars, points);
     assert_eq!(expected_product, product);
+}
+
+/// Tests the non-adjacent form for a Pallas scalar.
+#[test]
+fn test_non_adjacent_form() {
+    let rng = thread_rng();
+
+    let scalar = pallas::Scalar::random(rng);
+    scalar_mul::tests::test_non_adjacent_form_for_scalar(5, scalar);
 }

--- a/src/scalar_mul/tests.rs
+++ b/src/scalar_mul/tests.rs
@@ -144,13 +144,13 @@ pub(crate) fn test_non_adjacent_form_for_scalar<Scalar: NonAdjacentForm>(w: usiz
     }
 
     // Check that the reconstructed scalar is not negative, and convert it to little-endian bytes.
-    let reconstructed_scalar = reconstructed_scalar
+    let reconstructed_scalar: [u8; 32] = reconstructed_scalar
         .to_biguint()
         .expect("The reconstructed scalar is negative.")
-        .to_bytes_le();
-
-    let reconstructed_scalar_bytes: [u8; 32] = reconstructed_scalar.try_into().unwrap();
+        .to_bytes_le()
+        .try_into()
+        .expect("Could not convert the reconstructed scalar to bytes.");
 
     // Check that the reconstructed scalar matches the original one.
-    assert_eq!(reconstructed_scalar_bytes, scalar.inner_to_bytes());
+    assert_eq!(reconstructed_scalar, scalar.inner_to_bytes());
 }

--- a/src/scalar_mul/tests.rs
+++ b/src/scalar_mul/tests.rs
@@ -144,13 +144,13 @@ pub(crate) fn test_non_adjacent_form_for_scalar<Scalar: NonAdjacentForm>(w: usiz
     }
 
     // Check that the reconstructed scalar is not negative, and convert it to little-endian bytes.
-    let reconstructed_scalar: [u8; 32] = reconstructed_scalar
+    let reconstructed_scalar = reconstructed_scalar
         .to_biguint()
         .expect("The reconstructed scalar is negative.")
-        .to_bytes_le()
-        .try_into()
-        .expect("Could not convert the reconstructed scalar to bytes.");
+        .to_bytes_le();
+
+    let reconstructed_scalar_bytes: [u8; 32] = reconstructed_scalar.try_into().unwrap();
 
     // Check that the reconstructed scalar matches the original one.
-    assert_eq!(reconstructed_scalar, scalar.inner_to_bytes());
+    assert_eq!(reconstructed_scalar_bytes, scalar.inner_to_bytes());
 }

--- a/src/scalar_mul/tests.rs
+++ b/src/scalar_mul/tests.rs
@@ -14,22 +14,25 @@ fn gen_jubjub_test_vectors() {
 
     let rng = thread_rng();
 
-    let scalars = [Scalar::random(rng.clone()), Scalar::random(rng.clone())];
+    let scalars = [
+        jubjub::Scalar::random(rng.clone()),
+        jubjub::Scalar::random(rng.clone()),
+    ];
     println!("Scalars:");
     for scalar in scalars {
         println!("{:?}", scalar.to_bytes());
     }
 
     let points = [
-        ExtendedPoint::random(rng.clone()),
-        ExtendedPoint::random(rng),
+        jubjub::ExtendedPoint::random(rng.clone()),
+        jubjub::ExtendedPoint::random(rng),
     ];
     println!("Points:");
     for point in points {
         println!("{:?}", point.to_bytes());
     }
 
-    let res = ExtendedPoint::vartime_multiscalar_mul(scalars, points);
+    let res = jubjub::ExtendedPoint::vartime_multiscalar_mul(scalars, points);
     println!("Result:");
     println!("{:?}", res.to_bytes());
 }
@@ -65,21 +68,22 @@ fn test_jubjub_vartime_multiscalar_mul() {
         131, 180, 48, 148, 72, 212, 148, 212, 240, 77, 244, 91, 213,
     ];
 
-    let scalars: Vec<Scalar> = scalars
+    let scalars: Vec<jubjub::Scalar> = scalars
         .into_iter()
-        .map(|s| Scalar::from_bytes(&s).expect("Could not deserialize a `jubjub::Scalar`."))
+        .map(|s| jubjub::Scalar::from_bytes(&s).expect("Could not deserialize a `jubjub::Scalar`."))
         .collect();
 
-    let points: Vec<ExtendedPoint> = points
+    let points: Vec<jubjub::ExtendedPoint> = points
         .into_iter()
         .map(|p| {
-            ExtendedPoint::from_bytes(&p).expect("Could not deserialize a `jubjub::ExtendedPoint`.")
+            jubjub::ExtendedPoint::from_bytes(&p)
+                .expect("Could not deserialize a `jubjub::ExtendedPoint`.")
         })
         .collect();
 
-    let expected_product = ExtendedPoint::from_bytes(&expected_product)
+    let expected_product = jubjub::ExtendedPoint::from_bytes(&expected_product)
         .expect("Could not deserialize a `jubjub::ExtendedPoint`.");
 
-    let product = ExtendedPoint::vartime_multiscalar_mul(scalars, points);
+    let product = jubjub::ExtendedPoint::vartime_multiscalar_mul(scalars, points);
     assert_eq!(expected_product, product);
 }

--- a/src/scalar_mul/tests.rs
+++ b/src/scalar_mul/tests.rs
@@ -149,7 +149,15 @@ pub(crate) fn test_non_adjacent_form_for_scalar<Scalar: NonAdjacentForm>(w: usiz
         .expect("The reconstructed scalar is negative.")
         .to_bytes_le();
 
-    let reconstructed_scalar_bytes: [u8; 32] = reconstructed_scalar.try_into().unwrap();
+    // Check that the reconstructed scalar is not too big.
+    assert!(reconstructed_scalar.len() <= 32);
+
+    // Convert the reconstructed scalar to a fixed byte array so we can compare it with the orginal
+    // scalar.
+    let mut reconstructed_scalar_bytes: [u8; 32] = [0; 32];
+    for (i, byte) in reconstructed_scalar.iter().enumerate() {
+        reconstructed_scalar_bytes[i] = *byte;
+    }
 
     // Check that the reconstructed scalar matches the original one.
     assert_eq!(reconstructed_scalar_bytes, scalar.inner_to_bytes());

--- a/src/scalar_mul/tests.rs
+++ b/src/scalar_mul/tests.rs
@@ -1,15 +1,18 @@
 use alloc::vec::Vec;
-use group::GroupEncoding;
-use jubjub::{ExtendedPoint, Scalar};
+use group::{ff::Field, GroupEncoding};
+use num_bigint::BigInt;
+use num_traits::Zero;
+use rand::thread_rng;
 
 use crate::scalar_mul::VartimeMultiscalarMul;
+
+use super::NonAdjacentForm;
 
 /// Generates test vectors for [`test_jubjub_vartime_multiscalar_mul`].
 // #[test]
 #[allow(dead_code)]
 fn gen_jubjub_test_vectors() {
-    use group::{ff::Field, Group};
-    use rand::thread_rng;
+    use group::Group;
     use std::println;
 
     let rng = thread_rng();
@@ -86,4 +89,76 @@ fn test_jubjub_vartime_multiscalar_mul() {
 
     let product = jubjub::ExtendedPoint::vartime_multiscalar_mul(scalars, points);
     assert_eq!(expected_product, product);
+}
+
+/// Tests the non-adjacent form for a Jubjub scalar.
+#[test]
+fn test_non_adjacent_form() {
+    let rng = thread_rng();
+
+    let scalar = jubjub::Scalar::random(rng);
+    test_non_adjacent_form_for_scalar(5, scalar);
+}
+
+/// Tests the non-adjacent form for a particular scalar.
+pub(crate) fn test_non_adjacent_form_for_scalar<Scalar: NonAdjacentForm>(w: usize, scalar: Scalar) {
+    let naf = scalar.non_adjacent_form(w);
+    let naf_length = Scalar::naf_length();
+
+    // Check that the computed w-NAF has the intended length.
+    assert_eq!(naf.len(), naf_length);
+
+    let w = u32::try_from(w).expect("The window `w` did not fit into `u32`.");
+
+    // `bound` <- 2^(w-1)
+    let bound = 2_i32.pow(w - 1);
+
+    // `valid_coeffs` <- a range of odd integers from -2^(w-1) to 2^(w-1)
+    let valid_coeffs: Vec<i32> = (-bound..bound).filter(|x| x.rem_euclid(2) == 1).collect();
+
+    let mut reconstructed_scalar: BigInt = Zero::zero();
+
+    // Reconstruct the original scalar, and check two general invariants for any w-NAF along the
+    // way.
+    let mut i = 0;
+    while i < naf_length {
+        if naf[i] != 0 {
+            // In a w-NAF, every nonzero coefficient `naf[i]` is an odd signed integer with
+            // -2^(w-1) < `naf[i]` < 2^(w-1).
+            assert!(valid_coeffs.contains(&i32::from(naf[i])));
+
+            // Incrementally keep reconstructing the original scalar.
+            reconstructed_scalar += naf[i] * BigInt::from(2).pow(i.try_into().unwrap());
+
+            // In a w-NAF, at most one of any `w` consecutive coefficients is nonzero.
+            for _ in 1..w {
+                i += 1;
+                if i >= naf_length {
+                    break;
+                }
+                assert_eq!(naf[i], 0)
+            }
+        }
+
+        i += 1;
+    }
+
+    // Check that the reconstructed scalar is not negative, and convert it to little-endian bytes.
+    let reconstructed_scalar = reconstructed_scalar
+        .to_biguint()
+        .expect("The reconstructed scalar is negative.")
+        .to_bytes_le();
+
+    // Check that the reconstructed scalar is not too big.
+    assert!(reconstructed_scalar.len() <= 32);
+
+    // Convert the reconstructed scalar to a fixed byte array so we can compare it with the orginal
+    // scalar.
+    let mut reconstructed_scalar_bytes: [u8; 32] = [0; 32];
+    for (i, byte) in reconstructed_scalar.iter().enumerate() {
+        reconstructed_scalar_bytes[i] = *byte;
+    }
+
+    // Check that the reconstructed scalar matches the original one.
+    assert_eq!(reconstructed_scalar_bytes, scalar.inner_to_bytes());
 }

--- a/src/scalar_mul/tests.rs
+++ b/src/scalar_mul/tests.rs
@@ -149,15 +149,7 @@ pub(crate) fn test_non_adjacent_form_for_scalar<Scalar: NonAdjacentForm>(w: usiz
         .expect("The reconstructed scalar is negative.")
         .to_bytes_le();
 
-    // Check that the reconstructed scalar is not too big.
-    assert!(reconstructed_scalar.len() <= 32);
-
-    // Convert the reconstructed scalar to a fixed byte array so we can compare it with the orginal
-    // scalar.
-    let mut reconstructed_scalar_bytes: [u8; 32] = [0; 32];
-    for (i, byte) in reconstructed_scalar.iter().enumerate() {
-        reconstructed_scalar_bytes[i] = *byte;
-    }
+    let reconstructed_scalar_bytes: [u8; 32] = reconstructed_scalar.try_into().unwrap();
 
     // Check that the reconstructed scalar matches the original one.
     assert_eq!(reconstructed_scalar_bytes, scalar.inner_to_bytes());


### PR DESCRIPTION
## Motivation

Close https://github.com/ZcashFoundation/zebra/issues/6341.

## Solution

This PR:

- Makes the NAF function generic and removes the two curve-specific implementations.
- Uses the appropriate NAF length for the individual curves, which reduces loop iterations in multiplication.
- Tests NAF invariants that result from the NAF definition.
- Tests that it's possible to reconstruct the original scalar from its NAF.