### PR TITLE
frost: move Randomizer out of round2 module for consistency

### DIFF
--- a/src/frost/redjubjub.rs
+++ b/src/frost/redjubjub.rs
@@ -332,9 +332,6 @@ pub mod round2 {
     /// shares into the joint signature.
     pub type SignatureShare = frost::round2::SignatureShare<J>;
 
-    /// A randomizer. A random scalar which is used to randomize the key.
-    pub type Randomizer = frost_rerandomized::Randomizer<J>;
-
     /// Performed once by each participant selected for the signing operation.
     ///
     /// Receives the message to be signed and a set of signing commitments and a set
@@ -358,6 +355,9 @@ pub type Signature = frost_rerandomized::frost_core::Signature<J>;
 
 /// Randomized parameters for a signing instance of randomized FROST.
 pub type RandomizedParams = frost_rerandomized::RandomizedParams<J>;
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<J>;
 
 /// Verifies each FROST(Jubjub, BLAKE2b-512) participant's signature share, and if all are valid,
 /// aggregates the shares into a signature to publish.

--- a/src/frost/redpallas.rs
+++ b/src/frost/redpallas.rs
@@ -482,9 +482,6 @@ pub mod round2 {
     /// shares into the joint signature.
     pub type SignatureShare = frost::round2::SignatureShare<P>;
 
-    /// A randomizer. A random scalar which is used to randomize the key.
-    pub type Randomizer = frost_rerandomized::Randomizer<P>;
-
     /// Performed once by each participant selected for the signing operation.
     ///
     /// Receives the message to be signed and a set of signing commitments and a set
@@ -508,6 +505,9 @@ pub type Signature = frost_rerandomized::frost_core::Signature<P>;
 
 /// Randomized parameters for a signing instance of randomized FROST.
 pub type RandomizedParams = frost_rerandomized::RandomizedParams<P>;
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<P>;
 
 /// Verifies each FROST(Pallas, BLAKE2b-512) participant's signature share, and if all are valid,
 /// aggregates the shares into a signature to publish.


### PR DESCRIPTION
While working on the demo I realized this was inconsistent. Currently we put in the round1/2 modules whatever types are _returned_ in round1/2, which is not the case (it's an input).