### PR TITLE
removes `std` dependency for `frost` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ std = ["blake2b_simd/std", "thiserror", "zeroize", "alloc",
        "serde"] # conditional compilation for serde not complete (issue #9)
 alloc = ["hex"]
 nightly = []
-frost = ["std", "frost-rerandomized"]
+frost = ["frost-rerandomized"]
 serde = ["dep:serde", "frost-rerandomized?/serde"]
 default = ["std"]
 


### PR DESCRIPTION
With release of FROST 2.0.0-rc.0, std is no longer required for frost. This PR makes reddsa with frost compatible with `no-std` environment.