### PR TITLE
ci: disable dependabot for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,3 @@ updates:
     interval: daily
     timezone: America/New_York
   open-pull-requests-limit: 10
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: America/New_York
-  open-pull-requests-limit: 10


### PR DESCRIPTION
We decided to update manually before each release.