### PR TITLE
Simon/avoiding cheater detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "frost-rerandomized"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3b10d9c1e9f298522510940b5b8c3d55040420517ec8d2bb86c4c2d1ae3ee"
+checksum = "4c5eb1ea58c0250b7ce834337f7b19e0417686d14ffc7f626137dea9149762d4"
 dependencies = [
  "derive-getters",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pasta_curves = { version = "0.5", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = { version = "2.0", optional = true }
-frost-rerandomized = { version = "2.1.0", optional = true, default-features = false, features = ["serialization", "cheater-detection"] }
+frost-rerandomized = { version = "2.2.0", optional = true, default-features = false, features = ["serialization"] }
 
 [dependencies.zeroize]
 version = "1"
@@ -50,7 +50,7 @@ rand_chacha = "0.3"
 serde_json = "1.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
-frost-rerandomized = { version = "2.1.0", features = ["test-impl"] }
+frost-rerandomized = { version = "2.2.0", features = ["test-impl"] }
 
 # `alloc` is only used in test code
 [dev-dependencies.pasta_curves]
@@ -58,14 +58,16 @@ version = "0.5"
 default-features = false
 features = ["alloc"]
 
+
 [features]
 std = ["blake2b_simd/std", "thiserror", "zeroize", "alloc", "frost-rerandomized?/std",
        "serde"] # conditional compilation for serde not complete (issue #9)
 alloc = ["hex"]
 nightly = []
 frost = ["frost-rerandomized", "alloc"]
+cheater-detection = ["frost-rerandomized?/cheater-detection"]
 serde = ["dep:serde", "frost-rerandomized?/serde"]
-default = ["std"]
+default = ["std", "cheater-detection"]
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ nightly = []
 frost = ["frost-rerandomized", "alloc"]
 cheater-detection = ["frost-rerandomized?/cheater-detection"]
 serde = ["dep:serde", "frost-rerandomized?/serde"]
-default = ["std", "cheater-detection"]
+default = ["std"]
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
We needed to turn off cheater detection as a default to be able to successfully generate signatures.

Check https://github.com/ZcashFoundation/reddsa/pull/248 and slack discussion https://nearone.slack.com/archives/C07UW93JVQ8/p1768783890314849 