### PR TITLE
Update to frost-rerandomized 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "debugless-unwrap"
-version = "0.0.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
+checksum = "b93fdcfc175d53094fca1d23d171685621bb67f1658413514f2053d575b3b38c"
 
 [[package]]
 name = "derive-getters"
@@ -388,9 +388,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "frost-core"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2619366c227233c0f817ae01156bd21b8cf74d2bd96cbe0889f4c2e266724e44"
+checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -407,15 +407,17 @@ dependencies = [
  "serde_json",
  "serdect",
  "thiserror",
+ "tokio",
  "visibility",
  "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]
 name = "frost-rerandomized"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5eb1ea58c0250b7ce834337f7b19e0417686d14ffc7f626137dea9149762d4"
+checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -667,6 +669,12 @@ dependencies = [
  "static_assertions",
  "subtle",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1094,6 +1102,27 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,25 +231,22 @@ checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -316,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "debugless-unwrap"
-version = "0.0.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
+checksum = "b93fdcfc175d53094fca1d23d171685621bb67f1658413514f2053d575b3b38c"
 
 [[package]]
 name = "derive-getters"
@@ -391,8 +388,8 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "frost-core"
-version = "2.0.0"
-source = "git+https://github.com/ZcashFoundation/frost.git?rev=ab8e2ef2f986480f079393729fb631ad44151aea#ab8e2ef2f986480f079393729fb631ad44151aea"
+version = "2.2.0"
+source = "git+https://github.com/ZcashFoundation/frost.git?rev=3ed40ad6e2278578a718e7b6053ce10f1c763c93#3ed40ad6e2278578a718e7b6053ce10f1c763c93"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -401,23 +398,24 @@ dependencies = [
  "derive-getters",
  "document-features",
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "postcard",
  "proptest",
  "rand_core",
  "serde",
  "serde_json",
  "serdect",
- "thiserror 1.0.69",
- "thiserror-nostd-notrait",
+ "thiserror",
+ "tokio",
  "visibility",
  "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]
 name = "frost-rerandomized"
-version = "2.0.0"
-source = "git+https://github.com/ZcashFoundation/frost.git?rev=ab8e2ef2f986480f079393729fb631ad44151aea#ab8e2ef2f986480f079393729fb631ad44151aea"
+version = "2.2.0"
+source = "git+https://github.com/ZcashFoundation/frost.git?rev=3ed40ad6e2278578a718e7b6053ce10f1c763c93#3ed40ad6e2278578a718e7b6053ce10f1c763c93"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -496,17 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +507,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -671,6 +667,12 @@ dependencies = [
  "static_assertions",
  "subtle",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "plotters"
@@ -862,7 +864,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror",
  "zeroize",
 ]
 
@@ -1072,31 +1074,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.11",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1111,26 +1093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror-nostd-notrait"
-version = "1.0.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
-dependencies = [
- "thiserror-nostd-notrait-impl",
-]
-
-[[package]]
-name = "thiserror-nostd-notrait-impl"
-version = "1.0.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1100,27 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,29 +256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,34 +391,33 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "frost-core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2619366c227233c0f817ae01156bd21b8cf74d2bd96cbe0889f4c2e266724e44"
+version = "2.0.0"
+source = "git+https://github.com/ZcashFoundation/frost.git?rev=ab8e2ef2f986480f079393729fb631ad44151aea#ab8e2ef2f986480f079393729fb631ad44151aea"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
- "criterion 0.6.0",
+ "criterion",
  "debugless-unwrap",
  "derive-getters",
  "document-features",
  "hex",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "postcard",
  "proptest",
  "rand_core",
  "serde",
  "serde_json",
  "serdect",
- "thiserror",
+ "thiserror 1.0.69",
+ "thiserror-nostd-notrait",
  "visibility",
  "zeroize",
 ]
 
 [[package]]
 name = "frost-rerandomized"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3b10d9c1e9f298522510940b5b8c3d55040420517ec8d2bb86c4c2d1ae3ee"
+version = "2.0.0"
+source = "git+https://github.com/ZcashFoundation/frost.git?rev=ab8e2ef2f986480f079393729fb631ad44151aea#ab8e2ef2f986480f079393729fb631ad44151aea"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -544,15 +520,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -879,7 +846,7 @@ dependencies = [
  "bincode",
  "blake2b_simd",
  "byteorder",
- "criterion 0.5.1",
+ "criterion",
  "frost-rerandomized",
  "group",
  "hex",
@@ -895,7 +862,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.11",
  "zeroize",
 ]
 
@@ -1105,11 +1072,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.11",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1117,6 +1104,26 @@ name = "thiserror-impl"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
+dependencies = [
+ "thiserror-nostd-notrait-impl",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "frost-core"
 version = "2.2.0"
-source = "git+https://github.com/ZcashFoundation/frost.git?rev=3ed40ad6e2278578a718e7b6053ce10f1c763c93#3ed40ad6e2278578a718e7b6053ce10f1c763c93"
+source = "git+https://github.com/ZcashFoundation/frost.git?rev=a926bdee78024990ac98fe5211d2a9905d6b9fab#a926bdee78024990ac98fe5211d2a9905d6b9fab"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -415,7 +415,7 @@ dependencies = [
 [[package]]
 name = "frost-rerandomized"
 version = "2.2.0"
-source = "git+https://github.com/ZcashFoundation/frost.git?rev=3ed40ad6e2278578a718e7b6053ce10f1c763c93#3ed40ad6e2278578a718e7b6053ce10f1c763c93"
+source = "git+https://github.com/ZcashFoundation/frost.git?rev=a926bdee78024990ac98fe5211d2a9905d6b9fab#a926bdee78024990ac98fe5211d2a9905d6b9fab"
 dependencies = [
  "derive-getters",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pasta_curves = { version = "0.5", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = { version = "2.0", optional = true }
-frost-rerandomized = { version = "2.2.0", optional = true, default-features = false, features = ["serialization", "cheater-detection"] }
+frost-rerandomized = { version = "3.0.0", optional = true, default-features = false, features = ["serialization"] }
 
 [dependencies.zeroize]
 version = "1"
@@ -50,7 +50,7 @@ rand_chacha = "0.3"
 serde_json = "1.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
-frost-rerandomized = { version = "2.2.0", features = ["test-impl"] }
+frost-rerandomized = { version = "3.0.0", features = ["test-impl"] }
 
 # `alloc` is only used in test code
 [dev-dependencies.pasta_curves]
@@ -59,7 +59,7 @@ default-features = false
 features = ["alloc"]
 
 [features]
-std = ["blake2b_simd/std", "thiserror", "zeroize", "alloc", "frost-rerandomized?/std",
+std = ["blake2b_simd/std", "thiserror", "zeroize", "alloc",
        "serde"] # conditional compilation for serde not complete (issue #9)
 alloc = ["hex"]
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ pasta_curves = { version = "0.5", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = { version = "2.0", optional = true }
-frost-rerandomized = { version = "2.1.0", optional = true, default-features = false, features = ["serialization", "cheater-detection"] }
+# frost-rerandomized = { version = "2.0.0", optional = true, default-features = false, features = ["serialization", "cheater-detection"] }
+frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "ab8e2ef2f986480f079393729fb631ad44151aea", optional = true, default-features = false, features = ["serialization", "cheater-detection"] }
 
 [dependencies.zeroize]
 version = "1"
@@ -50,7 +51,8 @@ rand_chacha = "0.3"
 serde_json = "1.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
-frost-rerandomized = { version = "2.1.0", features = ["test-impl"] }
+# frost-rerandomized = { version = "2.0.0", features = ["test-impl"] }
+frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "ab8e2ef2f986480f079393729fb631ad44151aea", features = ["test-impl"] }
 
 # `alloc` is only used in test code
 [dev-dependencies.pasta_curves]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = { version = "2.0", optional = true }
 # frost-rerandomized = { version = "2.2.0", optional = true, default-features = false, features = ["serialization"] }
-frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "3ed40ad6e2278578a718e7b6053ce10f1c763c93", optional = true, default-features = false, features = ["serialization"] }
+frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "a926bdee78024990ac98fe5211d2a9905d6b9fab", optional = true, default-features = false, features = ["serialization"] }
 
 [dependencies.zeroize]
 version = "1"
@@ -52,7 +52,7 @@ serde_json = "1.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 # frost-rerandomized = { version = "2.2.0", features = ["test-impl"] }
-frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "3ed40ad6e2278578a718e7b6053ce10f1c763c93", features = ["test-impl"] }
+frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "a926bdee78024990ac98fe5211d2a9905d6b9fab", features = ["test-impl"] }
 
 # `alloc` is only used in test code
 [dev-dependencies.pasta_curves]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ pasta_curves = { version = "0.5", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = { version = "2.0", optional = true }
-# frost-rerandomized = { version = "2.0.0", optional = true, default-features = false, features = ["serialization", "cheater-detection"] }
-frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "ab8e2ef2f986480f079393729fb631ad44151aea", optional = true, default-features = false, features = ["serialization", "cheater-detection"] }
+# frost-rerandomized = { version = "2.2.0", optional = true, default-features = false, features = ["serialization"] }
+frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "3ed40ad6e2278578a718e7b6053ce10f1c763c93", optional = true, default-features = false, features = ["serialization"] }
 
 [dependencies.zeroize]
 version = "1"
@@ -41,7 +41,7 @@ optional = true
 
 [dev-dependencies]
 bincode = "1"
-criterion = "0.5"
+criterion = "0.6"
 hex = "0.4.3"
 proptest-derive = "0.5"
 lazy_static = "1.5"
@@ -51,8 +51,8 @@ rand_chacha = "0.3"
 serde_json = "1.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
-# frost-rerandomized = { version = "2.0.0", features = ["test-impl"] }
-frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "ab8e2ef2f986480f079393729fb631ad44151aea", features = ["test-impl"] }
+# frost-rerandomized = { version = "2.2.0", features = ["test-impl"] }
+frost-rerandomized = { git = "https://github.com/ZcashFoundation/frost.git", rev = "3ed40ad6e2278578a718e7b6053ce10f1c763c93", features = ["test-impl"] }
 
 # `alloc` is only used in test code
 [dev-dependencies.pasta_curves]

--- a/benches/frost.rs
+++ b/benches/frost.rs
@@ -92,12 +92,13 @@ fn bench_rerandomized_sign<
 
         let message = "message to sign".as_bytes();
         let signing_package = frost::SigningPackage::new(commitments, message);
-        let randomizer_params = frost_rerandomized::RandomizedParams::new(
-            pubkeys.verifying_key(),
-            &signing_package,
-            &mut rng,
-        )
-        .unwrap();
+        let (randomizer_params, randomizer_seed) =
+            frost_rerandomized::RandomizedParams::new_from_commitments(
+                pubkeys.verifying_key(),
+                signing_package.signing_commitments(),
+                &mut rng,
+            )
+            .unwrap();
         let randomizer = *randomizer_params.randomizer();
 
         group.bench_with_input(
@@ -111,12 +112,13 @@ fn bench_rerandomized_sign<
                 b.iter(|| {
                     let participant_identifier = 1u16.try_into().expect("should be nonzero");
                     let key_package = key_packages.get(&participant_identifier).unwrap();
-                    let nonces_to_use = &nonces.get(&participant_identifier).unwrap();
-                    frost_rerandomized::sign(
+                    let nonces_to_use: &&frost::round1::SigningNonces<C> =
+                        &nonces.get(&participant_identifier).unwrap();
+                    frost_rerandomized::sign_with_randomizer_seed(
                         signing_package,
                         nonces_to_use,
                         key_package,
-                        *randomizer_params.randomizer(),
+                        &randomizer_seed,
                     )
                     .unwrap();
                 })
@@ -127,11 +129,11 @@ fn bench_rerandomized_sign<
         for participant_identifier in nonces.keys() {
             let key_package = key_packages.get(participant_identifier).unwrap();
             let nonces_to_use = &nonces.get(participant_identifier).unwrap();
-            let signature_share = frost_rerandomized::sign(
+            let signature_share = frost_rerandomized::sign_with_randomizer_seed(
                 &signing_package,
                 nonces_to_use,
                 key_package,
-                *randomizer_params.randomizer(),
+                &randomizer_seed,
             )
             .unwrap();
             signature_shares.insert(*key_package.identifier(), signature_share);

--- a/src/frost/redjubjub.rs
+++ b/src/frost/redjubjub.rs
@@ -1,12 +1,15 @@
-//! Rerandomized FROST with Jubjub curve.
+#![doc = include_str!("redjubjub/README.md")]
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
 
 use alloc::collections::BTreeMap;
 
+use frost_rerandomized::RandomizedCiphersuite;
 use group::GroupEncoding;
 #[cfg(feature = "alloc")]
 use group::{ff::Field as _, ff::PrimeField, Group as _};
+
+pub mod rerandomized;
 
 // Re-exports in our public API
 #[cfg(feature = "serde")]
@@ -14,7 +17,6 @@ pub use frost_rerandomized::frost_core::serde;
 pub use frost_rerandomized::frost_core::{
     self as frost, Ciphersuite, Field, FieldError, Group, GroupError,
 };
-use frost_rerandomized::RandomizedCiphersuite;
 pub use rand_core;
 
 use rand_core::{CryptoRng, RngCore};
@@ -345,46 +347,17 @@ pub mod round2 {
     ///
     /// Assumes the participant has already determined which nonce corresponds with
     /// the commitment that was assigned by the coordinator in the SigningPackage.
-    #[deprecated(
-        note = "switch to sign_with_randomizer_seed(), passing a seed generated with RandomizedParams::new_from_commitments()"
-    )]
     pub fn sign(
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
-        randomizer: Randomizer,
     ) -> Result<SignatureShare, Error> {
-        #[allow(deprecated)]
-        frost_rerandomized::sign(signing_package, signer_nonces, key_package, randomizer)
-    }
-
-    /// Re-randomized FROST signing using the given `randomizer_seed`, which should
-    /// be sent from the Coordinator using a confidential channel.
-    ///
-    /// See [`frost::round2::sign`] for documentation on the other parameters.
-    pub fn sign_with_randomizer_seed<C: RandomizedCiphersuite>(
-        signing_package: &SigningPackage,
-        signer_nonces: &round1::SigningNonces,
-        key_package: &keys::KeyPackage,
-        randomizer_seed: &[u8],
-    ) -> Result<SignatureShare, Error> {
-        frost_rerandomized::sign_with_randomizer_seed(
-            signing_package,
-            signer_nonces,
-            key_package,
-            randomizer_seed,
-        )
+        frost::round2::sign(signing_package, signer_nonces, key_package)
     }
 }
 
 /// A Schnorr signature on FROST(Jubjub, BLAKE2b-512).
 pub type Signature = frost_rerandomized::frost_core::Signature<J>;
-
-/// Randomized parameters for a signing instance of randomized FROST.
-pub type RandomizedParams = frost_rerandomized::RandomizedParams<J>;
-
-/// A randomizer. A random scalar which is used to randomize the key.
-pub type Randomizer = frost_rerandomized::Randomizer<J>;
 
 /// Verifies each FROST(Jubjub, BLAKE2b-512) participant's signature share, and if all are valid,
 /// aggregates the shares into a signature to publish.
@@ -405,16 +378,28 @@ pub fn aggregate(
     signing_package: &SigningPackage,
     signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
     pubkeys: &keys::PublicKeyPackage,
-    randomized_params: &RandomizedParams,
 ) -> Result<Signature, Error> {
-    frost_rerandomized::aggregate(
+    frost::aggregate(signing_package, signature_shares, pubkeys)
+}
+
+/// The type of cheater detection to use.
+pub type CheaterDetection = frost::CheaterDetection;
+
+/// Like [`aggregate()`], but allow specifying a specific cheater detection
+/// strategy.
+pub fn aggregate_custom(
+    signing_package: &SigningPackage,
+    signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
+    pubkeys: &keys::PublicKeyPackage,
+    cheater_detection: CheaterDetection,
+) -> Result<Signature, Error> {
+    frost::aggregate_custom(
         signing_package,
         signature_shares,
         pubkeys,
-        randomized_params,
+        cheater_detection,
     )
 }
-
 /// A signing key for a Schnorr signature on FROST(Jubjub, BLAKE2b-512).
 pub type SigningKey = frost_rerandomized::frost_core::SigningKey<J>;
 

--- a/src/frost/redjubjub.rs
+++ b/src/frost/redjubjub.rs
@@ -345,13 +345,35 @@ pub mod round2 {
     ///
     /// Assumes the participant has already determined which nonce corresponds with
     /// the commitment that was assigned by the coordinator in the SigningPackage.
+    #[deprecated(
+        note = "switch to sign_with_randomizer_seed(), passing a seed generated with RandomizedParams::new_from_commitments()"
+    )]
     pub fn sign(
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
         randomizer: Randomizer,
     ) -> Result<SignatureShare, Error> {
+        #[allow(deprecated)]
         frost_rerandomized::sign(signing_package, signer_nonces, key_package, randomizer)
+    }
+
+    /// Re-randomized FROST signing using the given `randomizer_seed`, which should
+    /// be sent from the Coordinator using a confidential channel.
+    ///
+    /// See [`frost::round2::sign`] for documentation on the other parameters.
+    pub fn sign_with_randomizer_seed<C: RandomizedCiphersuite>(
+        signing_package: &SigningPackage,
+        signer_nonces: &round1::SigningNonces,
+        key_package: &keys::KeyPackage,
+        randomizer_seed: &[u8],
+    ) -> Result<SignatureShare, Error> {
+        frost_rerandomized::sign_with_randomizer_seed(
+            signing_package,
+            signer_nonces,
+            key_package,
+            randomizer_seed,
+        )
     }
 }
 

--- a/src/frost/redjubjub.rs
+++ b/src/frost/redjubjub.rs
@@ -400,6 +400,7 @@ pub fn aggregate_custom(
         cheater_detection,
     )
 }
+
 /// A signing key for a Schnorr signature on FROST(Jubjub, BLAKE2b-512).
 pub type SigningKey = frost_rerandomized::frost_core::SigningKey<J>;
 

--- a/src/frost/redjubjub/README.md
+++ b/src/frost/redjubjub/README.md
@@ -1,7 +1,14 @@
 An implementation of Schnorr signatures on the Jubjub curve for both single and threshold numbers
 of signers (FROST).
 
-## Example: key generation with trusted dealer and FROST signing
+This crate is a re-export of the ciphersuite-generic
+[frost-core](https://crates.io/crates/frost-core) crate, parametrized with the
+Pallas curve. For more details, refer to [The ZF FROST
+Book](https://frost.zfnd.org/).
+
+<!-- PLACEHOLDER -->
+
+## Example: key generation with trusted dealer and rerandomized FROST signing
 
 Creating a key with a trusted dealer and splitting into shares; then signing a message
 and aggregating the signature. Note that the example just simulates a distributed
@@ -10,73 +17,94 @@ scenario in a single thread and it abstracts away any communication between peer
 
 ```rust
 use reddsa::frost::redjubjub as frost;
-use rand::thread_rng;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 let max_signers = 5;
 let min_signers = 3;
-let (shares, pubkeys) = frost::keys::keygen_with_dealer(max_signers, min_signers, &mut rng)?;
+let (shares, pubkey_package) = frost::keys::generate_with_dealer(
+    max_signers,
+    min_signers,
+    frost::keys::IdentifierList::Default,
+    &mut rng,
+)?;
 
-// Verifies the secret shares from the dealer and stores them in a HashMap.
-// In practice, each KeyPackage must be sent to its respective participant
+// Verifies the secret shares from the dealer and store them in a BTreeMap.
+// In practice, the KeyPackages must be sent to its respective participants
 // through a confidential and authenticated channel.
-let key_packages: HashMap<_, _> = shares
-    .into_iter()
-    .map(|share| Ok((share.identifier, frost::keys::KeyPackage::try_from(share)?)))
-    .collect::<Result<_, _>>()?;
+let mut key_packages: BTreeMap<_, _> = BTreeMap::new();
 
-let mut nonces = HashMap::new();
-let mut commitments = HashMap::new();
+for (identifier, secret_share) in shares {
+    # // ANCHOR: tkg_verify
+    let key_package = frost::keys::KeyPackage::try_from(secret_share)?;
+    # // ANCHOR_END: tkg_verify
+    key_packages.insert(identifier, key_package);
+}
+
+let mut nonces_map = BTreeMap::new();
+let mut commitments_map = BTreeMap::new();
 
 ////////////////////////////////////////////////////////////////////////////
 // Round 1: generating nonces and signing commitments for each participant
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_index in 1..(min_signers as u16 + 1) {
+for participant_index in 1..=min_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
+    let key_package = &key_packages[&participant_identifier];
     // Generate one (1) nonce and one SigningCommitments instance for each
     // participant, up to _threshold_.
-    let (nonce, commitment) = frost::round1::commit(
-        participant_identifier,
-        key_packages[&participant_identifier].secret_share(),
+    # // ANCHOR: round1_commit
+    let (nonces, commitments) = frost::round1::commit(
+        key_package.signing_share(),
         &mut rng,
     );
-    // In practice, the nonces and commitments must be sent to the coordinator
+    # // ANCHOR_END: round1_commit
+    // In practice, the nonces must be kept by the participant to use in the
+    // next round, while the commitment must be sent to the coordinator
     // (or to every other participant if there is no coordinator) using
     // an authenticated channel.
-    nonces.insert(participant_identifier, nonce);
-    commitments.insert(participant_identifier, commitment);
+    nonces_map.insert(participant_identifier, nonces);
+    commitments_map.insert(participant_identifier, commitments);
 }
 
 // This is what the signature aggregator / coordinator needs to do:
 // - decide what message to sign
 // - take one (unused) commitment per signing participant
-let mut signature_shares = Vec::new();
+let mut signature_shares = BTreeMap::new();
+# // ANCHOR: round2_package
 let message = "message to sign".as_bytes();
-let comms = commitments.clone().into_values().collect();
-// In practice, the SigningPackage must be sent to all participants
-// involved in the current signing (at least min_signers participants),
-// using an authenticated channel (and confidential if the message is secret).
-let signing_package = frost::SigningPackage::new(comms, message.to_vec());
+# // In practice, the SigningPackage must be sent to all participants
+# // involved in the current signing (at least min_signers participants),
+# // using an authenticate channel (and confidential if the message is secret),
+# // along with the `randomizer_seed`.
+let signing_package = frost::SigningPackage::new(commitments_map, message);
+let (randomizer_params, randomizer_seed) = frost::rerandomized::RandomizedParams::new_from_commitments(
+    pubkey_package.verifying_key(),
+    signing_package.signing_commitments(),
+    &mut rng,
+)
+.unwrap();
+# // ANCHOR_END: round2_package
 
 ////////////////////////////////////////////////////////////////////////////
 // Round 2: each participant generates their signature share
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_identifier in nonces.keys() {
+for participant_identifier in nonces_map.keys() {
     let key_package = &key_packages[participant_identifier];
 
-    let nonces_to_use = &nonces[participant_identifier];
+    let nonces = &nonces_map[participant_identifier];
 
     // Each participant generates their signature share.
-    let signature_share = frost::round2::sign(&signing_package, nonces_to_use, key_package)?;
+    # // ANCHOR: round2_sign
+    let signature_share = frost::rerandomized::sign_with_randomizer_seed(&signing_package, nonces, key_package, &randomizer_seed)?;
+    # // ANCHOR_END: round2_sign
 
     // In practice, the signature share must be sent to the Coordinator
     // using an authenticated channel.
-    signature_shares.push(signature_share);
+    signature_shares.insert(*participant_identifier, signature_share);
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -85,14 +113,20 @@ for participant_identifier in nonces.keys() {
 ////////////////////////////////////////////////////////////////////////////
 
 // Aggregate (also verifies the signature shares)
-let group_signature = frost::aggregate(&signing_package, &signature_shares[..], &pubkeys)?;
+# // ANCHOR: aggregate
+let group_signature = frost::rerandomized::aggregate(&signing_package, &signature_shares, &pubkey_package, &randomizer_params)?;
+# // ANCHOR_END: aggregate
 
-// Check that the threshold signature can be verified by the group public
-// key (the verification key).
-assert!(pubkeys
-    .group_public
+
+// Check that the threshold signature can be verified by the rerandomized group
+// public key (the verification key).
+# // ANCHOR: verify
+let is_signature_valid = randomizer_params
+    .randomized_verifying_key()
     .verify(message, &group_signature)
-    .is_ok());
+    .is_ok();
+# // ANCHOR_END: verify
+assert!(is_signature_valid);
 
 # Ok::<(), frost::Error>(())
 ```

--- a/src/frost/redjubjub/keys/repairable.rs
+++ b/src/frost/redjubjub/keys/repairable.rs
@@ -25,21 +25,21 @@ pub type Sigma = frost::keys::repairable::Sigma<JubjubBlake2b512>;
 /// `participant` recover their share.
 ///
 /// Returns a BTreeMap mapping which value should be sent to which participant.
-pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
+pub fn repair_share_part1<C: Ciphersuite, R: RngCore + CryptoRng>(
     helpers: &[Identifier],
     key_package_i: &KeyPackage,
     rng: &mut R,
     participant: Identifier,
 ) -> Result<BTreeMap<Identifier, Delta>, Error> {
-    frost::keys::repairable::repair_share_step_1(helpers, key_package_i, rng, participant)
+    frost::keys::repairable::repair_share_part1(helpers, key_package_i, rng, participant)
 }
 
 /// Step 2 of RTS.
 ///
 /// Generates the "sigma" value from all `deltas` received from all helpers.
 /// The "sigma" value must be sent to the participant repairing their share.
-pub fn repair_share_step_2(deltas: &[Delta]) -> Sigma {
-    frost::keys::repairable::repair_share_step_2::<JubjubBlake2b512>(deltas)
+pub fn repair_share_part2(deltas: &[Delta]) -> Sigma {
+    frost::keys::repairable::repair_share_part2::<JubjubBlake2b512>(deltas)
 }
 
 /// Step 3 of RTS.
@@ -51,10 +51,10 @@ pub fn repair_share_step_2(deltas: &[Delta]) -> Sigma {
 /// Returns an error if the `min_signers` field is not set in the `PublicKeyPackage`.
 /// This happens for `PublicKeyPackage`s created before the 3.0.0 release;
 /// in that case, the user should set the `min_signers` field manually.
-pub fn repair_share_step_3(
+pub fn repair_share_part3(
     sigmas: &[Sigma],
     identifier: Identifier,
     public_key_package: &PublicKeyPackage,
 ) -> Result<KeyPackage, Error> {
-    frost::keys::repairable::repair_share_step_3(sigmas, identifier, public_key_package)
+    frost::keys::repairable::repair_share_part3(sigmas, identifier, public_key_package)
 }

--- a/src/frost/redjubjub/keys/repairable.rs
+++ b/src/frost/redjubjub/keys/repairable.rs
@@ -6,50 +6,55 @@
 
 use alloc::collections::BTreeMap;
 
-use jubjub::Scalar;
-
 use crate::frost::redjubjub::{
-    frost, Ciphersuite, CryptoRng, Error, Identifier, JubjubBlake2b512, RngCore,
+    frost,
+    keys::{KeyPackage, PublicKeyPackage},
+    Ciphersuite, CryptoRng, Error, Identifier, JubjubBlake2b512, RngCore,
 };
 
-use super::{SecretShare, VerifiableSecretSharingCommitment};
+/// A delta value which is the output of step 1 of RTS.
+pub type Delta = frost::keys::repairable::Delta<JubjubBlake2b512>;
+
+/// A sigma value which is the output of step 2 of RTS.
+pub type Sigma = frost::keys::repairable::Sigma<JubjubBlake2b512>;
 
 /// Step 1 of RTS.
 ///
-/// Generates the "delta" values from `helper_i` to help `participant` recover their share
-/// where `helpers` contains the identifiers of all the helpers (including `helper_i`), and `share_i`
-/// is the share of `helper_i`.
+/// Generates the "delta" values from the helper with `key_package_i` to send to
+/// `helpers` (which includes the helper with `key_package_i`), to help
+/// `participant` recover their share.
 ///
-/// Returns a HashMap mapping which value should be sent to which participant.
+/// Returns a BTreeMap mapping which value should be sent to which participant.
 pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
     helpers: &[Identifier],
-    share_i: &SecretShare,
+    key_package_i: &KeyPackage,
     rng: &mut R,
     participant: Identifier,
-) -> Result<BTreeMap<Identifier, Scalar>, Error> {
-    frost::keys::repairable::repair_share_step_1(helpers, share_i, rng, participant)
+) -> Result<BTreeMap<Identifier, Delta>, Error> {
+    frost::keys::repairable::repair_share_step_1(helpers, key_package_i, rng, participant)
 }
 
 /// Step 2 of RTS.
 ///
-/// Generates the `sigma` values from all `deltas` received from `helpers`
-/// to help `participant` recover their share.
-/// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
-///
-/// Returns a scalar
-pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
-    frost::keys::repairable::repair_share_step_2::<JubjubBlake2b512>(deltas_j)
+/// Generates the "sigma" value from all `deltas` received from all helpers.
+/// The "sigma" value must be sent to the participant repairing their share.
+pub fn repair_share_step_2(deltas: &[Delta]) -> Sigma {
+    frost::keys::repairable::repair_share_step_2::<JubjubBlake2b512>(deltas)
 }
 
-/// Step 3 of RTS
+/// Step 3 of RTS.
 ///
-/// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
-/// is made up of the `identifier`and `commitment` of the `participant` as well as the
-/// `value` which is the `SigningShare`.
+/// The participant with the given `identifier` recovers their `KeyPackage`
+/// with the "sigma" values received from all helpers and the `PublicKeyPackage`
+/// of the group (which can be sent by any of the helpers).
+///
+/// Returns an error if the `min_signers` field is not set in the `PublicKeyPackage`.
+/// This happens for `PublicKeyPackage`s created before the 3.0.0 release;
+/// in that case, the user should set the `min_signers` field manually.
 pub fn repair_share_step_3(
-    sigmas: &[Scalar],
+    sigmas: &[Sigma],
     identifier: Identifier,
-    commitment: &VerifiableSecretSharingCommitment,
-) -> SecretShare {
-    frost::keys::repairable::repair_share_step_3(sigmas, identifier, commitment)
+    public_key_package: &PublicKeyPackage,
+) -> Result<KeyPackage, Error> {
+    frost::keys::repairable::repair_share_step_3(sigmas, identifier, public_key_package)
 }

--- a/src/frost/redjubjub/rerandomized.rs
+++ b/src/frost/redjubjub/rerandomized.rs
@@ -1,0 +1,67 @@
+//! FROST implementation supporting re-randomizable keys.
+
+use crate::frost::redjubjub as frost;
+
+use alloc::collections::btree_map::BTreeMap;
+
+/// Re-randomized FROST signing using the given `randomizer_seed`, which should
+/// be sent from the Coordinator using a confidential channel.
+///
+/// See [`crate::round2::sign`] for documentation on the other parameters.
+pub fn sign_with_randomizer_seed(
+    signing_package: &frost::SigningPackage,
+    signer_nonces: &frost::round1::SigningNonces,
+    key_package: &frost::keys::KeyPackage,
+    randomizer_seed: &[u8],
+) -> Result<frost::round2::SignatureShare, frost::Error> {
+    frost_rerandomized::sign_with_randomizer_seed::<frost::JubjubBlake2b512>(
+        signing_package,
+        signer_nonces,
+        key_package,
+        randomizer_seed,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`].
+///
+/// See [`frost_core::aggregate`] for documentation on the other parameters.
+pub fn aggregate(
+    signing_package: &frost::SigningPackage,
+    signature_shares: &BTreeMap<frost::Identifier, frost::round2::SignatureShare>,
+    pubkeys: &frost::keys::PublicKeyPackage,
+    randomized_params: &RandomizedParams,
+) -> Result<frost::Signature, frost::Error> {
+    frost_rerandomized::aggregate::<frost::JubjubBlake2b512>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        randomized_params,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`] using the given cheater detection strategy.
+///
+/// See [`frost_core::aggregate_custom`] for documentation on the other parameters.
+pub fn aggregate_custom(
+    signing_package: &frost::SigningPackage,
+    signature_shares: &BTreeMap<frost::Identifier, frost::round2::SignatureShare>,
+    pubkeys: &frost::keys::PublicKeyPackage,
+    cheater_detection: frost::CheaterDetection,
+    randomized_params: &RandomizedParams,
+) -> Result<frost::Signature, frost::Error> {
+    frost_rerandomized::aggregate_custom::<frost::JubjubBlake2b512>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+        randomized_params,
+    )
+}
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<frost::JubjubBlake2b512>;
+
+/// Randomized parameters for a signing instance of randomized FROST.
+pub type RandomizedParams = frost_rerandomized::RandomizedParams<frost::JubjubBlake2b512>;

--- a/src/frost/redpallas.rs
+++ b/src/frost/redpallas.rs
@@ -326,8 +326,7 @@ pub mod keys {
 
         /// Convert the given type to make sure the group public key has an even
         /// Y coordinate. `is_even` can be specified if evenness was already
-        /// determined beforehand. Returns a boolean indicating if the original
-        /// type had an even Y, and a (possibly converted) value with even Y.
+        /// determined beforehand.
         fn into_even_y(self, is_even: Option<bool>) -> Self;
     }
 
@@ -502,13 +501,35 @@ pub mod round2 {
     ///
     /// Assumes the participant has already determined which nonce corresponds with
     /// the commitment that was assigned by the coordinator in the SigningPackage.
+    #[deprecated(
+        note = "switch to sign_with_randomizer_seed(), passing a seed generated with RandomizedParams::new_from_commitments()"
+    )]
     pub fn sign(
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
         randomizer: Randomizer,
     ) -> Result<SignatureShare, Error> {
+        #[allow(deprecated)]
         frost_rerandomized::sign(signing_package, signer_nonces, key_package, randomizer)
+    }
+
+    /// Re-randomized FROST signing using the given `randomizer_seed`, which should
+    /// be sent from the Coordinator using a confidential channel.
+    ///
+    /// See [`frost::round2::sign`] for documentation on the other parameters.
+    pub fn sign_with_randomizer_seed<C: RandomizedCiphersuite>(
+        signing_package: &SigningPackage,
+        signer_nonces: &round1::SigningNonces,
+        key_package: &keys::KeyPackage,
+        randomizer_seed: &[u8],
+    ) -> Result<SignatureShare, Error> {
+        frost_rerandomized::sign_with_randomizer_seed(
+            signing_package,
+            signer_nonces,
+            key_package,
+            randomizer_seed,
+        )
     }
 }
 

--- a/src/frost/redpallas.rs
+++ b/src/frost/redpallas.rs
@@ -370,8 +370,7 @@ pub mod keys {
                         (*i, vs)
                     })
                     .collect();
-                // TODO: change new() to allow None and remove unwrap()
-                PublicKeyPackage::new(verifying_shares, verifying_key, self.min_signers().unwrap())
+                PublicKeyPackage::new(verifying_shares, verifying_key, self.min_signers())
             } else {
                 self
             }

--- a/src/frost/redpallas.rs
+++ b/src/frost/redpallas.rs
@@ -1,7 +1,4 @@
-//! Rerandomized FROST with Pallas curve.
-//!
-//! This also re-exposes the FROST functions already parametrized with the
-//! Pallas curve.
+#![doc = include_str!("redpallas/README.md")]
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
 
@@ -12,6 +9,8 @@ use group::GroupEncoding;
 #[cfg(feature = "alloc")]
 use group::{ff::Field as FFField, ff::PrimeField, Group as FFGroup};
 use pasta_curves::pallas;
+
+pub mod rerandomized;
 
 // Re-exports in our public API
 #[cfg(feature = "serde")]
@@ -518,46 +517,17 @@ pub mod round2 {
     ///
     /// Assumes the participant has already determined which nonce corresponds with
     /// the commitment that was assigned by the coordinator in the SigningPackage.
-    #[deprecated(
-        note = "switch to sign_with_randomizer_seed(), passing a seed generated with RandomizedParams::new_from_commitments()"
-    )]
     pub fn sign(
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
-        randomizer: Randomizer,
     ) -> Result<SignatureShare, Error> {
-        #[allow(deprecated)]
-        frost_rerandomized::sign(signing_package, signer_nonces, key_package, randomizer)
-    }
-
-    /// Re-randomized FROST signing using the given `randomizer_seed`, which should
-    /// be sent from the Coordinator using a confidential channel.
-    ///
-    /// See [`frost::round2::sign`] for documentation on the other parameters.
-    pub fn sign_with_randomizer_seed<C: RandomizedCiphersuite>(
-        signing_package: &SigningPackage,
-        signer_nonces: &round1::SigningNonces,
-        key_package: &keys::KeyPackage,
-        randomizer_seed: &[u8],
-    ) -> Result<SignatureShare, Error> {
-        frost_rerandomized::sign_with_randomizer_seed(
-            signing_package,
-            signer_nonces,
-            key_package,
-            randomizer_seed,
-        )
+        frost::round2::sign(signing_package, signer_nonces, key_package)
     }
 }
 
 /// A Schnorr signature on FROST(Pallas, BLAKE2b-512).
 pub type Signature = frost_rerandomized::frost_core::Signature<P>;
-
-/// Randomized parameters for a signing instance of randomized FROST.
-pub type RandomizedParams = frost_rerandomized::RandomizedParams<P>;
-
-/// A randomizer. A random scalar which is used to randomize the key.
-pub type Randomizer = frost_rerandomized::Randomizer<P>;
 
 /// Verifies each FROST(Pallas, BLAKE2b-512) participant's signature share, and if all are valid,
 /// aggregates the shares into a signature to publish.
@@ -578,13 +548,26 @@ pub fn aggregate(
     signing_package: &SigningPackage,
     signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
     pubkeys: &keys::PublicKeyPackage,
-    randomized_params: &RandomizedParams,
 ) -> Result<Signature, Error> {
-    frost_rerandomized::aggregate(
+    frost::aggregate(signing_package, signature_shares, pubkeys)
+}
+
+/// The type of cheater detection to use.
+pub type CheaterDetection = frost::CheaterDetection;
+
+/// Like [`aggregate()`], but allow specifying a specific cheater detection
+/// strategy.
+pub fn aggregate_custom(
+    signing_package: &SigningPackage,
+    signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
+    pubkeys: &keys::PublicKeyPackage,
+    cheater_detection: CheaterDetection,
+) -> Result<Signature, Error> {
+    frost::aggregate_custom(
         signing_package,
         signature_shares,
         pubkeys,
-        randomized_params,
+        cheater_detection,
     )
 }
 

--- a/src/frost/redpallas.rs
+++ b/src/frost/redpallas.rs
@@ -342,8 +342,7 @@ pub mod keys {
 
         /// Convert the given type to make sure the group public key has an even
         /// Y coordinate. `is_even` can be specified if evenness was already
-        /// determined beforehand. Returns a boolean indicating if the original
-        /// type had an even Y, and a (possibly converted) value with even Y.
+        /// determined beforehand.
         fn into_even_y(self, is_even: Option<bool>) -> Self;
     }
 
@@ -518,13 +517,35 @@ pub mod round2 {
     ///
     /// Assumes the participant has already determined which nonce corresponds with
     /// the commitment that was assigned by the coordinator in the SigningPackage.
+    #[deprecated(
+        note = "switch to sign_with_randomizer_seed(), passing a seed generated with RandomizedParams::new_from_commitments()"
+    )]
     pub fn sign(
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
         randomizer: Randomizer,
     ) -> Result<SignatureShare, Error> {
+        #[allow(deprecated)]
         frost_rerandomized::sign(signing_package, signer_nonces, key_package, randomizer)
+    }
+
+    /// Re-randomized FROST signing using the given `randomizer_seed`, which should
+    /// be sent from the Coordinator using a confidential channel.
+    ///
+    /// See [`frost::round2::sign`] for documentation on the other parameters.
+    pub fn sign_with_randomizer_seed<C: RandomizedCiphersuite>(
+        signing_package: &SigningPackage,
+        signer_nonces: &round1::SigningNonces,
+        key_package: &keys::KeyPackage,
+        randomizer_seed: &[u8],
+    ) -> Result<SignatureShare, Error> {
+        frost_rerandomized::sign_with_randomizer_seed(
+            signing_package,
+            signer_nonces,
+            key_package,
+            randomizer_seed,
+        )
     }
 }
 

--- a/src/frost/redpallas.rs
+++ b/src/frost/redpallas.rs
@@ -371,7 +371,8 @@ pub mod keys {
                         (*i, vs)
                     })
                     .collect();
-                PublicKeyPackage::new(verifying_shares, verifying_key)
+                // TODO: change new() to allow None and remove unwrap()
+                PublicKeyPackage::new(verifying_shares, verifying_key, self.min_signers().unwrap())
             } else {
                 self
             }

--- a/src/frost/redpallas.rs
+++ b/src/frost/redpallas.rs
@@ -355,7 +355,8 @@ pub mod keys {
                         (*i, vs)
                     })
                     .collect();
-                PublicKeyPackage::new(verifying_shares, verifying_key)
+                // TODO: change new() to allow None and remove unwrap()
+                PublicKeyPackage::new(verifying_shares, verifying_key, self.min_signers().unwrap())
             } else {
                 self
             }

--- a/src/frost/redpallas.rs
+++ b/src/frost/redpallas.rs
@@ -1,10 +1,4 @@
-//! Rerandomized FROST with Pallas curve.
-//!
-//! This also re-exposes the FROST functions already parametrized with the
-//! Pallas curve. Note that if you use the generic frost-core functions instead,
-//! you will not get public keys with guaranteed even Y coordinate, and will
-//! need to convert them using the [`EvenY`] trait; see its documentation for
-//! details.
+#![doc = include_str!("redpallas/README.md")]
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
 
@@ -15,6 +9,8 @@ use group::GroupEncoding;
 #[cfg(feature = "alloc")]
 use group::{ff::Field as FFField, ff::PrimeField, Group as FFGroup};
 use pasta_curves::pallas;
+
+pub mod rerandomized;
 
 // Re-exports in our public API
 #[cfg(feature = "serde")]
@@ -502,46 +498,17 @@ pub mod round2 {
     ///
     /// Assumes the participant has already determined which nonce corresponds with
     /// the commitment that was assigned by the coordinator in the SigningPackage.
-    #[deprecated(
-        note = "switch to sign_with_randomizer_seed(), passing a seed generated with RandomizedParams::new_from_commitments()"
-    )]
     pub fn sign(
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
-        randomizer: Randomizer,
     ) -> Result<SignatureShare, Error> {
-        #[allow(deprecated)]
-        frost_rerandomized::sign(signing_package, signer_nonces, key_package, randomizer)
-    }
-
-    /// Re-randomized FROST signing using the given `randomizer_seed`, which should
-    /// be sent from the Coordinator using a confidential channel.
-    ///
-    /// See [`frost::round2::sign`] for documentation on the other parameters.
-    pub fn sign_with_randomizer_seed<C: RandomizedCiphersuite>(
-        signing_package: &SigningPackage,
-        signer_nonces: &round1::SigningNonces,
-        key_package: &keys::KeyPackage,
-        randomizer_seed: &[u8],
-    ) -> Result<SignatureShare, Error> {
-        frost_rerandomized::sign_with_randomizer_seed(
-            signing_package,
-            signer_nonces,
-            key_package,
-            randomizer_seed,
-        )
+        frost::round2::sign(signing_package, signer_nonces, key_package)
     }
 }
 
 /// A Schnorr signature on FROST(Pallas, BLAKE2b-512).
 pub type Signature = frost_rerandomized::frost_core::Signature<P>;
-
-/// Randomized parameters for a signing instance of randomized FROST.
-pub type RandomizedParams = frost_rerandomized::RandomizedParams<P>;
-
-/// A randomizer. A random scalar which is used to randomize the key.
-pub type Randomizer = frost_rerandomized::Randomizer<P>;
 
 /// Verifies each FROST(Pallas, BLAKE2b-512) participant's signature share, and if all are valid,
 /// aggregates the shares into a signature to publish.
@@ -562,13 +529,26 @@ pub fn aggregate(
     signing_package: &SigningPackage,
     signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
     pubkeys: &keys::PublicKeyPackage,
-    randomized_params: &RandomizedParams,
 ) -> Result<Signature, Error> {
-    frost_rerandomized::aggregate(
+    frost::aggregate(signing_package, signature_shares, pubkeys)
+}
+
+/// The type of cheater detection to use.
+pub type CheaterDetection = frost::CheaterDetection;
+
+/// Like [`aggregate()`], but allow specifying a specific cheater detection
+/// strategy.
+pub fn aggregate_custom(
+    signing_package: &SigningPackage,
+    signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
+    pubkeys: &keys::PublicKeyPackage,
+    cheater_detection: CheaterDetection,
+) -> Result<Signature, Error> {
+    frost::aggregate_custom(
         signing_package,
         signature_shares,
         pubkeys,
-        randomized_params,
+        cheater_detection,
     )
 }
 

--- a/src/frost/redpallas/README.md
+++ b/src/frost/redpallas/README.md
@@ -1,6 +1,13 @@
 An implementation of Schnorr signatures on the Pallas curve for both single and threshold numbers
 of signers (FROST).
 
+This crate is a re-export of the ciphersuite-generic
+[frost-core](https://crates.io/crates/frost-core) crate, parametrized with the
+Pallas curve. For more details, refer to [The ZF FROST
+Book](https://frost.zfnd.org/).
+
+<!-- PLACEHOLDER -->
+
 ## Example: key generation with trusted dealer and FROST signing
 
 Creating a key with a trusted dealer and splitting into shares; then signing a message
@@ -10,73 +17,94 @@ scenario in a single thread and it abstracts away any communication between peer
 
 ```rust
 use reddsa::frost::redpallas as frost;
-use rand::thread_rng;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 let max_signers = 5;
 let min_signers = 3;
-let (shares, pubkeys) = frost::keys::keygen_with_dealer(max_signers, min_signers, &mut rng)?;
+let (shares, pubkey_package) = frost::keys::generate_with_dealer(
+    max_signers,
+    min_signers,
+    frost::keys::IdentifierList::Default,
+    &mut rng,
+)?;
 
-// Verifies the secret shares from the dealer and stores them in a HashMap.
-// In practice, each KeyPackage must be sent to its respective participant
+// Verifies the secret shares from the dealer and store them in a BTreeMap.
+// In practice, the KeyPackages must be sent to its respective participants
 // through a confidential and authenticated channel.
-let key_packages: HashMap<_, _> = shares
-    .into_iter()
-    .map(|share| Ok((share.identifier, frost::keys::KeyPackage::try_from(share)?)))
-    .collect::<Result<_, _>>()?;
+let mut key_packages: BTreeMap<_, _> = BTreeMap::new();
 
-let mut nonces = HashMap::new();
-let mut commitments = HashMap::new();
+for (identifier, secret_share) in shares {
+    # // ANCHOR: tkg_verify
+    let key_package = frost::keys::KeyPackage::try_from(secret_share)?;
+    # // ANCHOR_END: tkg_verify
+    key_packages.insert(identifier, key_package);
+}
+
+let mut nonces_map = BTreeMap::new();
+let mut commitments_map = BTreeMap::new();
 
 ////////////////////////////////////////////////////////////////////////////
 // Round 1: generating nonces and signing commitments for each participant
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_index in 1..(min_signers as u16 + 1) {
+for participant_index in 1..=min_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
+    let key_package = &key_packages[&participant_identifier];
     // Generate one (1) nonce and one SigningCommitments instance for each
     // participant, up to _threshold_.
-    let (nonce, commitment) = frost::round1::commit(
-        participant_identifier,
-        key_packages[&participant_identifier].secret_share(),
+    # // ANCHOR: round1_commit
+    let (nonces, commitments) = frost::round1::commit(
+        key_package.signing_share(),
         &mut rng,
     );
-    // In practice, the nonces and commitments must be sent to the coordinator
+    # // ANCHOR_END: round1_commit
+    // In practice, the nonces must be kept by the participant to use in the
+    // next round, while the commitment must be sent to the coordinator
     // (or to every other participant if there is no coordinator) using
     // an authenticated channel.
-    nonces.insert(participant_identifier, nonce);
-    commitments.insert(participant_identifier, commitment);
+    nonces_map.insert(participant_identifier, nonces);
+    commitments_map.insert(participant_identifier, commitments);
 }
 
 // This is what the signature aggregator / coordinator needs to do:
 // - decide what message to sign
 // - take one (unused) commitment per signing participant
-let mut signature_shares = Vec::new();
+let mut signature_shares = BTreeMap::new();
+# // ANCHOR: round2_package
 let message = "message to sign".as_bytes();
-let comms = commitments.clone().into_values().collect();
-// In practice, the SigningPackage must be sent to all participants
-// involved in the current signing (at least min_signers participants),
-// using an authenticated channel (and confidential if the message is secret).
-let signing_package = frost::SigningPackage::new(comms, message.to_vec());
+# // In practice, the SigningPackage must be sent to all participants
+# // involved in the current signing (at least min_signers participants),
+# // using an authenticate channel (and confidential if the message is secret),
+# // along with the `randomizer_seed`.
+let signing_package = frost::SigningPackage::new(commitments_map, message);
+let (randomizer_params, randomizer_seed) = frost::rerandomized::RandomizedParams::new_from_commitments(
+    pubkey_package.verifying_key(),
+    signing_package.signing_commitments(),
+    &mut rng,
+)
+.unwrap();
+# // ANCHOR_END: round2_package
 
 ////////////////////////////////////////////////////////////////////////////
 // Round 2: each participant generates their signature share
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_identifier in nonces.keys() {
+for participant_identifier in nonces_map.keys() {
     let key_package = &key_packages[participant_identifier];
 
-    let nonces_to_use = &nonces[participant_identifier];
+    let nonces = &nonces_map[participant_identifier];
 
     // Each participant generates their signature share.
-    let signature_share = frost::round2::sign(&signing_package, nonces_to_use, key_package)?;
+    # // ANCHOR: round2_sign
+    let signature_share = frost::rerandomized::sign_with_randomizer_seed(&signing_package, nonces, key_package, &randomizer_seed)?;
+    # // ANCHOR_END: round2_sign
 
     // In practice, the signature share must be sent to the Coordinator
     // using an authenticated channel.
-    signature_shares.push(signature_share);
+    signature_shares.insert(*participant_identifier, signature_share);
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -85,14 +113,20 @@ for participant_identifier in nonces.keys() {
 ////////////////////////////////////////////////////////////////////////////
 
 // Aggregate (also verifies the signature shares)
-let group_signature = frost::aggregate(&signing_package, &signature_shares[..], &pubkeys)?;
+# // ANCHOR: aggregate
+let group_signature = frost::rerandomized::aggregate(&signing_package, &signature_shares, &pubkey_package, &randomizer_params)?;
+# // ANCHOR_END: aggregate
 
-// Check that the threshold signature can be verified by the group public
-// key (the verification key).
-assert!(pubkeys
-    .group_public
+
+// Check that the threshold signature can be verified by the rerandomized group
+// public key (the verification key).
+# // ANCHOR: verify
+let is_signature_valid = randomizer_params
+    .randomized_verifying_key()
     .verify(message, &group_signature)
-    .is_ok());
+    .is_ok();
+# // ANCHOR_END: verify
+assert!(is_signature_valid);
 
 # Ok::<(), frost::Error>(())
 ```

--- a/src/frost/redpallas/README.md
+++ b/src/frost/redpallas/README.md
@@ -76,7 +76,7 @@ let mut signature_shares = BTreeMap::new();
 let message = "message to sign".as_bytes();
 # // In practice, the SigningPackage must be sent to all participants
 # // involved in the current signing (at least min_signers participants),
-# // using an authenticate channel (and confidential if the message is secret),
+# // using an authenticated channel (and confidential if the message is secret),
 # // along with the `randomizer_seed`.
 let signing_package = frost::SigningPackage::new(commitments_map, message);
 let (randomizer_params, randomizer_seed) = frost::rerandomized::RandomizedParams::new_from_commitments(

--- a/src/frost/redpallas/keys/repairable.rs
+++ b/src/frost/redpallas/keys/repairable.rs
@@ -25,21 +25,21 @@ pub type Sigma = frost::keys::repairable::Sigma<PallasBlake2b512>;
 /// `participant` recover their share.
 ///
 /// Returns a BTreeMap mapping which value should be sent to which participant.
-pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
+pub fn repair_share_part1<C: Ciphersuite, R: RngCore + CryptoRng>(
     helpers: &[Identifier],
     key_package_i: &KeyPackage,
     rng: &mut R,
     participant: Identifier,
 ) -> Result<BTreeMap<Identifier, Delta>, Error> {
-    frost::keys::repairable::repair_share_step_1(helpers, key_package_i, rng, participant)
+    frost::keys::repairable::repair_share_part1(helpers, key_package_i, rng, participant)
 }
 
 /// Step 2 of RTS.
 ///
 /// Generates the "sigma" value from all `deltas` received from all helpers.
 /// The "sigma" value must be sent to the participant repairing their share.
-pub fn repair_share_step_2(deltas: &[Delta]) -> Sigma {
-    frost::keys::repairable::repair_share_step_2::<PallasBlake2b512>(deltas)
+pub fn repair_share_part2(deltas: &[Delta]) -> Sigma {
+    frost::keys::repairable::repair_share_part2::<PallasBlake2b512>(deltas)
 }
 
 /// Step 3 of RTS.
@@ -51,10 +51,10 @@ pub fn repair_share_step_2(deltas: &[Delta]) -> Sigma {
 /// Returns an error if the `min_signers` field is not set in the `PublicKeyPackage`.
 /// This happens for `PublicKeyPackage`s created before the 3.0.0 release;
 /// in that case, the user should set the `min_signers` field manually.
-pub fn repair_share_step_3(
+pub fn repair_share_part3(
     sigmas: &[Sigma],
     identifier: Identifier,
     public_key_package: &PublicKeyPackage,
 ) -> Result<KeyPackage, Error> {
-    frost::keys::repairable::repair_share_step_3(sigmas, identifier, public_key_package)
+    frost::keys::repairable::repair_share_part3(sigmas, identifier, public_key_package)
 }

--- a/src/frost/redpallas/keys/repairable.rs
+++ b/src/frost/redpallas/keys/repairable.rs
@@ -6,50 +6,55 @@
 
 use alloc::collections::BTreeMap;
 
-use pasta_curves::pallas::Scalar;
-
 use crate::frost::redpallas::{
-    frost, Ciphersuite, CryptoRng, Error, Identifier, PallasBlake2b512, RngCore,
+    frost,
+    keys::{KeyPackage, PublicKeyPackage},
+    Ciphersuite, CryptoRng, Error, Identifier, PallasBlake2b512, RngCore,
 };
 
-use super::{SecretShare, VerifiableSecretSharingCommitment};
+/// A delta value which is the output of step 1 of RTS.
+pub type Delta = frost::keys::repairable::Delta<PallasBlake2b512>;
+
+/// A sigma value which is the output of step 2 of RTS.
+pub type Sigma = frost::keys::repairable::Sigma<PallasBlake2b512>;
 
 /// Step 1 of RTS.
 ///
-/// Generates the "delta" values from `helper_i` to help `participant` recover their share
-/// where `helpers` contains the identifiers of all the helpers (including `helper_i`), and `share_i`
-/// is the share of `helper_i`.
+/// Generates the "delta" values from the helper with `key_package_i` to send to
+/// `helpers` (which includes the helper with `key_package_i`), to help
+/// `participant` recover their share.
 ///
 /// Returns a BTreeMap mapping which value should be sent to which participant.
 pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
     helpers: &[Identifier],
-    share_i: &SecretShare,
+    key_package_i: &KeyPackage,
     rng: &mut R,
     participant: Identifier,
-) -> Result<BTreeMap<Identifier, Scalar>, Error> {
-    frost::keys::repairable::repair_share_step_1(helpers, share_i, rng, participant)
+) -> Result<BTreeMap<Identifier, Delta>, Error> {
+    frost::keys::repairable::repair_share_step_1(helpers, key_package_i, rng, participant)
 }
 
 /// Step 2 of RTS.
 ///
-/// Generates the `sigma` values from all `deltas` received from `helpers`
-/// to help `participant` recover their share.
-/// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
-///
-/// Returns a scalar
-pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
-    frost::keys::repairable::repair_share_step_2::<PallasBlake2b512>(deltas_j)
+/// Generates the "sigma" value from all `deltas` received from all helpers.
+/// The "sigma" value must be sent to the participant repairing their share.
+pub fn repair_share_step_2(deltas: &[Delta]) -> Sigma {
+    frost::keys::repairable::repair_share_step_2::<PallasBlake2b512>(deltas)
 }
 
-/// Step 3 of RTS
+/// Step 3 of RTS.
 ///
-/// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
-/// is made up of the `identifier`and `commitment` of the `participant` as well as the
-/// `value` which is the `SigningShare`.
+/// The participant with the given `identifier` recovers their `KeyPackage`
+/// with the "sigma" values received from all helpers and the `PublicKeyPackage`
+/// of the group (which can be sent by any of the helpers).
+///
+/// Returns an error if the `min_signers` field is not set in the `PublicKeyPackage`.
+/// This happens for `PublicKeyPackage`s created before the 3.0.0 release;
+/// in that case, the user should set the `min_signers` field manually.
 pub fn repair_share_step_3(
-    sigmas: &[Scalar],
+    sigmas: &[Sigma],
     identifier: Identifier,
-    commitment: &VerifiableSecretSharingCommitment,
-) -> SecretShare {
-    frost::keys::repairable::repair_share_step_3(sigmas, identifier, commitment)
+    public_key_package: &PublicKeyPackage,
+) -> Result<KeyPackage, Error> {
+    frost::keys::repairable::repair_share_step_3(sigmas, identifier, public_key_package)
 }

--- a/src/frost/redpallas/rerandomized.rs
+++ b/src/frost/redpallas/rerandomized.rs
@@ -1,0 +1,67 @@
+//! FROST implementation supporting re-randomizable keys.
+
+use crate::frost::redpallas as frost;
+
+use alloc::collections::btree_map::BTreeMap;
+
+/// Re-randomized FROST signing using the given `randomizer_seed`, which should
+/// be sent from the Coordinator using a confidential channel.
+///
+/// See [`crate::round2::sign`] for documentation on the other parameters.
+pub fn sign_with_randomizer_seed(
+    signing_package: &frost::SigningPackage,
+    signer_nonces: &frost::round1::SigningNonces,
+    key_package: &frost::keys::KeyPackage,
+    randomizer_seed: &[u8],
+) -> Result<frost::round2::SignatureShare, frost::Error> {
+    frost_rerandomized::sign_with_randomizer_seed::<frost::PallasBlake2b512>(
+        signing_package,
+        signer_nonces,
+        key_package,
+        randomizer_seed,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`].
+///
+/// See [`frost_core::aggregate`] for documentation on the other parameters.
+pub fn aggregate(
+    signing_package: &frost::SigningPackage,
+    signature_shares: &BTreeMap<frost::Identifier, frost::round2::SignatureShare>,
+    pubkeys: &frost::keys::PublicKeyPackage,
+    randomized_params: &RandomizedParams,
+) -> Result<frost::Signature, frost::Error> {
+    frost_rerandomized::aggregate::<frost::PallasBlake2b512>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        randomized_params,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`] using the given cheater detection strategy.
+///
+/// See [`frost_core::aggregate_custom`] for documentation on the other parameters.
+pub fn aggregate_custom(
+    signing_package: &frost::SigningPackage,
+    signature_shares: &BTreeMap<frost::Identifier, frost::round2::SignatureShare>,
+    pubkeys: &frost::keys::PublicKeyPackage,
+    cheater_detection: frost::CheaterDetection,
+    randomized_params: &RandomizedParams,
+) -> Result<frost::Signature, frost::Error> {
+    frost_rerandomized::aggregate_custom::<frost::PallasBlake2b512>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+        randomized_params,
+    )
+}
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<frost::PallasBlake2b512>;
+
+/// Randomized parameters for a signing instance of randomized FROST.
+pub type RandomizedParams = frost_rerandomized::RandomizedParams<frost::PallasBlake2b512>;

--- a/tests/frost_redpallas.rs
+++ b/tests/frost_redpallas.rs
@@ -93,7 +93,6 @@ fn check_even_y_frost_core() {
     for _ in 0..32 {
         let max_signers = 5;
         let min_signers = 3;
-        // Generate keys with frost-core function, which doesn't ensure even Y
         let (secret_shares, public_key_package) =
             frost::keys::generate_with_dealer::<PallasBlake2b512, _>(
                 max_signers,


### PR DESCRIPTION
I ended up doing more cleanups, sorry for not having them in a separate PR, but they are in separate commits:

- Previously, the rerandomized API was forced to users by exposing the rerandomized sign/aggregate in the place of the regular sign/aggregate. Here I undid that and made the ciphersuites follow the regular FROST ciphersuites; sign/aggregate are regular FROST and rerandomized API is in the `rerandomized` submodule. I also update the READMEs to follow the other ciphersuites but I also changed it to use rerandomization

Closes https://github.com/ZcashFoundation/reddsa/pull/250