### PR TITLE
fix: release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into main


### PR DESCRIPTION
Aims to fix the release drafter [workflow failure](https://github.com/ZcashFoundation/reddsa/actions/runs/26192302753/job/77063478663), so that the 0.5.2 release is unblocked