### PR TITLE
Add zeroization for signing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Entries are listed in reverse chronological order.
 
+## Unreleased
+
+* Added `Zeroize` support for `SigningKey` when the `zeroize` feature is enabled.
+
 ## 0.5.2
 
 * The `Debug` implementation of `SigningKey` now redacts the signing key value.
@@ -70,4 +74,3 @@ relative to `redjubjub 0.4.0`:
     specification) should continue to use previous versions of this crate, until
     they can either move the checks into their own code, or migrate their
     consensus rules to match the RedDSA specification.
-

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -8,6 +8,8 @@
 // - Deirdre Connolly <deirdre@zfnd.org>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
+#[cfg(feature = "zeroize")]
+use core::sync::atomic::{compiler_fence, Ordering};
 use core::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -18,8 +20,12 @@ use crate::{
     private::SealedScalar, Error, Randomizer, SigType, Signature, SpendAuth, VerificationKey,
 };
 
+#[cfg(feature = "zeroize")]
+use group::ff::Field;
 use group::{ff::PrimeField, GroupEncoding};
 use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 /// A RedDSA signing key.
 #[derive(Copy, Clone)]
@@ -30,6 +36,18 @@ use rand_core::{CryptoRng, RngCore};
 pub struct SigningKey<T: SigType> {
     sk: T::Scalar,
     pk: VerificationKey<T>,
+}
+
+#[cfg(feature = "zeroize")]
+impl<T: SigType> Zeroize for SigningKey<T> {
+    fn zeroize(&mut self) {
+        // The verification key is public. Erase the secret scalar with a volatile
+        // write so the compiler cannot optimize it away before the value is freed.
+        unsafe {
+            core::ptr::write_volatile(&mut self.sk, T::Scalar::ZERO);
+        }
+        compiler_fence(Ordering::SeqCst);
+    }
 }
 
 impl<T: SigType> fmt::Debug for SigningKey<T> {
@@ -146,5 +164,25 @@ impl<T: SigType> SigningKey<T> {
             s_bytes,
             _marker: PhantomData,
         }
+    }
+}
+
+#[cfg(all(test, feature = "zeroize"))]
+mod tests {
+    use super::SigningKey;
+    use crate::orchard::SpendAuth;
+    use zeroize::Zeroize;
+
+    #[test]
+    fn zeroize_erases_secret_scalar() {
+        let mut key = SigningKey::<SpendAuth>::try_from([
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ])
+        .unwrap();
+
+        key.zeroize();
+
+        assert_eq!(<[u8; 32]>::from(key), [0; 32]);
     }
 }


### PR DESCRIPTION
Adds `Zeroize` support for `SigningKey` behind the existing `zeroize` feature. The secret scalar is erased with a volatile write and compiler fence; the cached verification key is public and remains intact. This lets `no_std` downstreams use `Zeroizing` without enabling `std`.

Tests: `cargo test --all-features`; `cargo build --no-default-features --features zeroize`.